### PR TITLE
test: add unit test for circularProgress in getChartSpecWithContext

### DIFF
--- a/packages/vmind/__tests__/unit/getChartSpecWithContext_circularProgress.test.ts
+++ b/packages/vmind/__tests__/unit/getChartSpecWithContext_circularProgress.test.ts
@@ -1,0 +1,73 @@
+import { getChartSpecWithContext } from '../../src/atom/chartGenerator/spec';
+import { ChartType } from '../../src/types';
+import { DataType, DataRole } from '@visactor/generate-vchart';
+
+const dataTable = [
+  {
+    brand_name: 'HUAWEI',
+    market_share: 0.194
+  },
+  {
+    brand_name: 'OPPO',
+    market_share: 0.146
+  },
+  {
+    brand_name: 'VIVO',
+    market_share: 0.17
+  },
+  {
+    brand_name: 'APPLE',
+    market_share: 0.141
+  },
+  {
+    brand_name: 'HONOR',
+    market_share: 0.137
+  },
+  {
+    brand_name: 'XIAOMI',
+    market_share: 0.166
+  },
+  {
+    brand_name: 'OTHERS',
+    market_share: 0.046
+  }
+];
+
+describe('getChartSpecWithContext - Circular Progress', () => {
+  it('should generate correct basic Pie Chart spec', () => {
+    const context = {
+      chartTypeList: Object.values(ChartType),
+      dataTable: dataTable,
+      transpose: false,
+      command: 'Generate a circular progress chart',
+      fieldInfo: [
+        {
+          fieldName: 'brand_name',
+          type: DataType.STRING,
+          role: DataRole.DIMENSION
+        },
+        {
+          fieldName: 'market_share',
+          type: DataType.RATIO,
+          role: DataRole.MEASURE
+        }
+      ],
+      cell: {
+        value: 'market_share',
+        category: 'brand_name'
+      },
+      chartType:'CIRCULAR_PROGRESS',
+      spec: {
+        type: 'circularProgress',
+        valueField: 'market_share',
+        categoryField: 'brand_name'
+      }
+    };
+    const { chartType, spec } = getChartSpecWithContext(context);
+    expect(chartType).toBe('Circular Progress');
+    expect(spec.type).toBe('circularProgress');
+    expect(spec.valueField).toBe('market_share');
+    expect(spec.categoryField).toBe('brand_name');
+    expect(spec.data.values).toEqual(dataTable);
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VChart/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Release
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

close #229

### 🔗 Related PR link

<!-- Put the related PR links here. -->

### 🐞 Bugserver case id

<!-- paste the `fileid` field in the bugserver case url -->

### 💡 Background and solution

### 💡 Background and solution

The unit test for the `circularProgress` chart type was missing in the `getChartSpecWithContext` function. 
I have added a new test file `getChartSpecWithContext_circularProgress.test.ts` to verify that the function correctly generates the spec when the chart type is set to `CIRCULAR_PROGRESS`.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add unit test for circularProgress |
| 🇨🇳 Chinese | 为环形进度图增加单元测试 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
