### PR TITLE
test: add dual axis chart spec coverage

### DIFF
--- a/packages/vmind/__tests__/unit/getChartSpecWithContext_dualAxis.test.ts
+++ b/packages/vmind/__tests__/unit/getChartSpecWithContext_dualAxis.test.ts
@@ -1,0 +1,60 @@
+import { getChartSpecWithContext } from '../../src/atom/chartGenerator/spec';
+import { ChartType } from '../../src/types';
+
+const dataTable = [
+  { name: 'A', value: 100, value1: 1000 },
+  { name: 'B', value: 80, value1: 800 }
+];
+
+describe('getChartSpecWithContext - Dual Axis Chart', () => {
+  it('should generate correct dual axis spec', () => {
+    const context = {
+      chartTypeList: Object.values(ChartType),
+      dataTable,
+      cell: {
+        x: 'name',
+        y: ['value', 'value1']
+      },
+      chartType: ChartType.DualAxisChart.toUpperCase(),
+      spec: {}
+    };
+
+    const { chartType, spec } = getChartSpecWithContext(context);
+
+    expect(chartType).toBe(ChartType.DualAxisChart);
+    expect(spec.type).toBe('common');
+    expect(spec.series).toHaveLength(2);
+    expect(spec.series[0]).toMatchObject({
+      type: 'bar',
+      id: 'mainSeries',
+      xField: 'name',
+      yField: 'value'
+    });
+    expect(spec.series[1]).toMatchObject({
+      type: 'line',
+      id: 'subSeries',
+      xField: 'name',
+      yField: 'value1'
+    });
+    expect(spec.series[0].data.values).toEqual([
+      { name: 'A', value: 100, value1: 1000, __VMIND_COLOR__: 'value' },
+      { name: 'B', value: 80, value1: 800, __VMIND_COLOR__: 'value' }
+    ]);
+    expect(spec.series[1].data.values).toEqual([
+      { name: 'A', value: 100, value1: 1000, __VMIND_COLOR__: 'value1' },
+      { name: 'B', value: 80, value1: 800, __VMIND_COLOR__: 'value1' }
+    ]);
+    expect(spec.axes).toEqual([
+      { id: 'dimensionAxis', type: 'band', orient: 'bottom' },
+      { id: 'measureAxisLeft', seriesId: 'mainSeries', type: 'linear', orient: 'left' },
+      {
+        id: 'measureAxisRight',
+        seriesId: 'subSeries',
+        type: 'linear',
+        orient: 'right',
+        tick: { visible: false },
+        grid: { visible: false }
+      }
+    ]);
+  });
+});


### PR DESCRIPTION
## What type of PR is this?

- [x] test

## What this PR does / why we need it

Adds unit coverage for `getChartSpecWithContext` when `chartType` is `Dual Axis Chart`.

The new test verifies that VMind's chart spec pipeline returns the expected VChart `common` spec, including the bar/line series, dual-axis field mapping, generated data values, and axis configuration.

Fixes #222

## Which issue(s) this PR fixes

Fixes #222

## Special notes for your reviewer

Validation run locally with Node 18.20.8:

- `npx --yes node@18 ../../common/scripts/install-run-rush.js install`
- `npx --yes node@18 ../../common/scripts/install-run-rushx.js test -- --runTestsByPath __tests__/unit/getChartSpecWithContext_dualAxis.test.ts`

I also ran `npx --yes node@18 ../../common/scripts/install-run-rushx.js compile`; it fails on pre-existing workspace type-resolution/type errors unrelated to this test-only change, mostly unresolved workspace package types such as `@visactor/generate-vchart` and `@visactor/chart-advisor`.
