### PR TITLE
test: add funnel chart spec coverage

### DIFF
--- a/packages/vmind/__tests__/unit/getChartSpecWithContext_funnel.test.ts
+++ b/packages/vmind/__tests__/unit/getChartSpecWithContext_funnel.test.ts
@@ -1,0 +1,91 @@
+import { getChartSpecWithContext } from '../../src/atom/chartGenerator/spec';
+import { ChartType } from '../../src/types';
+
+const dataTable = [
+  { stage: 'Visit', count: 1000 },
+  { stage: 'Signup', count: 400 },
+  { stage: 'Pay', count: 120 }
+];
+
+describe('getChartSpecWithContext - Funnel Chart', () => {
+  it('should generate correct funnel spec and sort values descending by measure', () => {
+    const context = {
+      chartTypeList: Object.values(ChartType),
+      dataTable: [
+        { stage: 'Pay', count: 120 },
+        { stage: 'Visit', count: 1000 },
+        { stage: 'Signup', count: 400 }
+      ],
+      cell: {
+        x: 'stage',
+        y: 'count'
+      },
+      chartType: ChartType.FunnelChart.toUpperCase(),
+      spec: {}
+    };
+
+    const { chartType, spec } = getChartSpecWithContext(context);
+
+    expect(chartType).toBe(ChartType.FunnelChart);
+    expect(spec.type).toBe('funnel');
+    expect(spec.categoryField).toBe('stage');
+    expect(spec.valueField).toBe('count');
+    expect(spec.label).toMatchObject({ visible: true });
+    expect(spec.data).toMatchObject({ id: 'data' });
+    expect(spec.data.values).toEqual(dataTable);
+  });
+
+  it('should map color/value cell aliases onto categoryField and valueField', () => {
+    const aliasedDataTable = [
+      { name: 'Awareness', value: 500 },
+      { name: 'Interest', value: 300 },
+      { name: 'Purchase', value: 80 }
+    ];
+    const context = {
+      chartTypeList: Object.values(ChartType),
+      dataTable: aliasedDataTable.map(item => ({ ...item })),
+      cell: {
+        color: 'name',
+        value: 'value'
+      },
+      chartType: ChartType.FunnelChart.toUpperCase(),
+      spec: {}
+    };
+
+    const { chartType, spec } = getChartSpecWithContext(context);
+
+    expect(chartType).toBe(ChartType.FunnelChart);
+    expect(spec.type).toBe('funnel');
+    expect(spec.categoryField).toBe('name');
+    expect(spec.valueField).toBe('value');
+    // Without cell.y, funnelData sort comparator falls back to undefined values and keeps input order.
+    expect(spec.data.values).toEqual(aliasedDataTable);
+  });
+
+  it('should prefer value field over y when both are present', () => {
+    const mixedDataTable = [
+      { step: 'A', metric: 10, amount: 90 },
+      { step: 'B', metric: 20, amount: 40 }
+    ];
+    const context = {
+      chartTypeList: Object.values(ChartType),
+      dataTable: mixedDataTable.map(item => ({ ...item })),
+      cell: {
+        x: 'step',
+        y: 'metric',
+        value: 'amount'
+      },
+      chartType: ChartType.FunnelChart.toUpperCase(),
+      spec: {}
+    };
+
+    const { chartType, spec } = getChartSpecWithContext(context);
+
+    expect(chartType).toBe(ChartType.FunnelChart);
+    expect(spec.type).toBe('funnel');
+    expect(spec.categoryField).toBe('step');
+    // valueField uses cell.value first; sorting still uses cell.y (metric) when present.
+    expect(spec.valueField).toBe('amount');
+    expect(spec.data.values.map((row: { step: string }) => row.step)).toEqual(['B', 'A']);
+  });
+});


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Test Case

### 🔗 Related issue link
Fixes #221

### 💡 Background and solution
#### Background
Add unit coverage for `getChartSpecWithContext()` when `chartType` is Funnel Chart, matching the existing chart-type unit-test series.

#### Solution
Added `packages/vmind/__tests__/unit/getChartSpecWithContext_funnel.test.ts` covering:
1. Core funnel spec fields (`type`, `categoryField`, `valueField`, label, data id)
2. Descending sort of data rows by measure (`cell.y`)
3. `color`/`value` cell aliases mapping to `categoryField`/`valueField`
4. Preferring `cell.value` over `cell.y` for `valueField` while still sorting by `cell.y` when present

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add unit tests for funnel chart specifications in getChartSpecWithContext |
| 🇨🇳 Chinese | 新增漏斗图 getChartSpecWithContext 单元测试 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed